### PR TITLE
Add 'deprecated' wrapper for property deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,25 @@ ButtonInput.propTypes = {
   value: childrenValueValidation
 ```
 
+---
+#### deprecated(propType, explanation)
+
+Helps with properties deprecations
+
+Example
+```js
+propTypes: {
+  collapsable: deprecated(React.PropTypes.bool, 'Use "collapsible" instead.')
+```
+
+In development mode it will write to the development console of a browser:
+```
+"collapsable" property of "ComponentName" has been deprecated.
+Use "collapsible" instead.
+```
+
+_Notice: this custom validator uses 'warning' package under the hood.
+And this package uses `console.error` channel instead of `console.warn`._
 
 [build-badge]: https://travis-ci.org/react-bootstrap/react-prop-types.svg?branch=master
 [build]: https://travis-ci.org/react-bootstrap/react-prop-types

--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
     "sinon-chai": "^2.8.0",
     "webpack": "^1.10.1",
     "yargs": "^3.14.0"
+  },
+  "dependencies": {
+    "warning": "^2.0.0"
   }
 }

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -1,0 +1,11 @@
+import warning from 'warning';
+
+export default function deprecated(propType, explanation){
+  return function(props, propName, componentName){
+    if (props[propName] != null) {
+      warning(false, `"${propName}" property of "${componentName}" has been deprecated.\n${explanation}`);
+    }
+
+    return propType(props, propName, componentName);
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,3 +4,4 @@ export elementType from './elementType';
 export keyOf from './keyOf';
 export singlePropFrom from './singlePropFrom';
 export all from './all';
+export deprecated from './deprecated';

--- a/test/deprecatedSpec.js
+++ b/test/deprecatedSpec.js
@@ -1,0 +1,37 @@
+/* eslint no-console: 0 */
+import React from 'react';
+import deprecated from '../src/deprecated';
+
+export function shouldError(about) {
+  console.error.called.should.be.true;
+  console.error.calledWithMatch(about).should.be.true;
+  console.error.reset();
+}
+
+describe('deprecated', function () {
+  beforeEach(function() {
+    // because 'warning' package uses console.error instead of console.warn
+    sinon.stub(console, 'error');
+  });
+
+  afterEach(function() {
+    console.error.restore();
+  });
+
+  function validate(prop) {
+    return deprecated(React.PropTypes.string, 'Read more at link')({pName: prop}, 'pName', 'ComponentName');
+  }
+
+  it('Should warn about deprecation and validate OK', function() {
+    let err = validate('value');
+    shouldError('"pName" property of "ComponentName" has been deprecated.\nRead more at link');
+    assert.notInstanceOf(err, Error);
+  });
+
+  it('Should warn about deprecation and throw validation error when property value is not OK', function() {
+    let err = validate({});
+    shouldError('"pName" property of "ComponentName" has been deprecated.\nRead more at link');
+    assert.instanceOf(err, Error);
+    assert.include(err.message, 'Invalid undefined `pName` of type `object` supplied to `ComponentName`');
+  });
+});


### PR DESCRIPTION
``` js
propTypes: {
  collapsable: deprecated(React.PropTypes.bool, 'Use "collapsible" instead.')
```
