### PR TITLE
Use es6 for arguments on all and singlePropFrom

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import elementType from 'react-prop-types/elementType'
 ```
 
 ---
-#### all(arrayOfValidators)
+#### all(...arrayOfValidators)
 
 This validator allows to have complex validation like this:
 ```js
@@ -40,14 +40,14 @@ propTypes: {
    * Display block buttons, only useful when used with the "vertical" prop.
    * @type {bool}
    */
-  block: CustomPropTypes.all([
+  block: CustomPropTypes.all(
     React.PropTypes.bool,
     function(props, propName, componentName) {
       if (props.block && !props.vertical) {
         return new Error('The block property requires the vertical property to be set to have any effect');
       }
     }
-  ])
+  )
 ```
 
 All validators will be validated one by one, stopping on the first failure.
@@ -196,7 +196,7 @@ React.render(<Example/>, mountNode);
 ```
 
 ---
-#### singlePropFrom(arrayOfPropertiesNames)
+#### singlePropFrom(...propertyNames)
 
 Used when it needs to assure that only one of properties can be used.
 
@@ -224,11 +224,10 @@ The possible solution
 ```js
 import { singlePropFrom } from 'react-prop-types/singlePropFrom';
 
-const propList = ['children', 'value'];
 const typeList = [React.PropTypes.number, React.PropTypes.string];
 
 function childrenValueValidation(props, propName, componentName) {
-  let error = singlePropFrom(propList)(props, propName, componentName);
+  let error = singlePropFrom('children', 'value')(props, propName, componentName);
   if (!error) {
     const oneOfType = React.PropTypes.oneOfType(typeList);
     error = oneOfType(props, propName, componentName);

--- a/src/all.js
+++ b/src/all.js
@@ -1,10 +1,10 @@
-export default function all(propTypes) {
+export default function all(...propTypes) {
   if (propTypes === undefined) {
     throw new Error('No validations provided');
   }
 
-  if (!(propTypes instanceof Array)) {
-    throw new Error('Invalid argument must be an array');
+  if (propTypes.some(propType => typeof propType !== 'function')) {
+    throw new Error('Invalid arguments, must be functions');
   }
 
   if (propTypes.length === 0) {

--- a/src/singlePropFrom.js
+++ b/src/singlePropFrom.js
@@ -7,7 +7,7 @@
  * @param componentName
  * @returns {Error|undefined}
  */
-export default function createSinglePropFromChecker(arrOfProps) {
+export default function createSinglePropFromChecker(...arrOfProps) {
   function validate(props, propName, componentName) {
     const usedPropCount = arrOfProps
       .map(listedProp => props[listedProp])

--- a/test/allSpec.js
+++ b/test/allSpec.js
@@ -22,20 +22,14 @@ describe('all', function() {
     }).to.throw(Error, /No validations provided/);
   });
 
-  it('with no validations provided', function() {
-    expect(() => {
-      all([]);
-    }).to.throw(Error, /No validations provided/);
-  });
-
   it('with invalid arguments provided', function() {
     expect(() => {
       all(1);
-    }).to.throw(Error, /Invalid argument must be an array/);
+    }).to.throw(Error, /Invalid arguments, must be functions/);
   });
 
   it('validates each validation', function() {
-    const allValidator = all(validators);
+    const allValidator = all(...validators);
 
     const result = allValidator(props, propName, componentName);
     expect(result).to.equal(undefined);
@@ -49,7 +43,7 @@ describe('all', function() {
   it('returns first validation failure', function() {
     const err = new Error('Failure');
     validators[1].returns(err);
-    const allValidator = all(validators);
+    const allValidator = all(...validators);
 
     const result = allValidator(props, propName, componentName);
     expect(result).to.equal(err);

--- a/test/singlePropFromSpec.js
+++ b/test/singlePropFromSpec.js
@@ -2,9 +2,7 @@ import singlePropFrom from '../src/singlePropFrom';
 
 describe('singlePropFrom', function() {
   function validate(testProps) {
-    const propList = ['children', 'value'];
-
-    return singlePropFrom(propList)(testProps, 'value', 'Component');
+    return singlePropFrom('children', 'value')(testProps, 'value', 'Component');
   }
 
   it('Should validate OK if only one listed prop in used', function() {


### PR DESCRIPTION
`singlePropFrom('children', 'value')` is much less verbose than `singlePropFrom(['children', 'value'])`. The same can be said for `all`.
