### PR TITLE
Update 'release-script' to human friendly version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "test": "npm run lint && karma start --single-run",
     "tdd": "karma start",
     "coverage": "COVERAGE=true karma start --single-run",
-    "patch": "release patch",
-    "minor": "release minor",
-    "major": "release major"
+    "release": "release"
   },
   "repository": {
     "type": "git",
@@ -64,7 +62,7 @@
     "mt-changelog": "^0.6.1",
     "node-libs-browser": "^0.5.2",
     "react": "^0.13.3",
-    "release-script": "^0.3.0",
+    "release-script": "^0.5.0",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0",
     "webpack": "^1.10.1",


### PR DESCRIPTION
Release script runs in "dry run" mode by default.
It prevents `danger` steps (`git push`, `npm publish` etc) from accidental running.

Addresses such https://github.com/react-bootstrap/react-bootstrap/pull/1325#issuecomment-140853722

https://github.com/AlexKVal/release-script/pull/19/files
