### PR TITLE
Add elementOfType checker

### DIFF
--- a/src/elementOfType.js
+++ b/src/elementOfType.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import {errMsg, createChainableTypeChecker} from './common';
+
+/**
+ * Returns a function to check whether a prop provides a particular type of
+ * element.
+ *
+ * @param elementType The type of element to check for.
+ */
+export default function createElementOfTypeChecker(elementType) {
+  /**
+   * Checks whether a prop provides a particular type of element.
+   *
+   * The type of element can only be provided as the return value of
+   * React.createClass(...)
+   *
+   * @param props
+   * @param propName
+   * @param componentName
+   * @returns {Error|undefined}
+   */
+  function validate(props, propName, componentName) {
+    const errBeginning = errMsg(props, propName, componentName,
+                                '. Expected a `' + elementType.displayName + '` Element');
+
+    if (!React.isValidElement(props[propName])) {
+      return new Error(errBeginning + ', got something that is not an Element.');
+    }
+    if (props[propName].type !== elementType) {
+      var invalidElementName = props[propName].type.displayName ||
+        props[propName].type.name ||
+        props[propName].type;
+      return new Error(errBeginning + ', got a `' + invalidElementName + '` Element instead.');
+    }
+    return null;
+  }
+  return createChainableTypeChecker(validate);
+}

--- a/src/elementOfType.js
+++ b/src/elementOfType.js
@@ -27,7 +27,7 @@ export default function createElementOfTypeChecker(elementType) {
       return new Error(errBeginning + ', got something that is not an Element.');
     }
     if (props[propName].type !== elementType) {
-      var invalidElementName = props[propName].type.displayName ||
+      const invalidElementName = props[propName].type.displayName ||
         props[propName].type.name ||
         props[propName].type;
       return new Error(errBeginning + ', got a `' + invalidElementName + '` Element instead.');


### PR DESCRIPTION
This checker ensures that the property is a React Element of the expected type.

This is useful for components where there is only a single valid type of child element. As an example, a `Tabs` element which only accepts `Tab` children.
