### PR TITLE
Making `all` validator chainable (isRequired)

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -21,7 +21,7 @@ export default function all(...propTypes) {
         return result;
       }
     }
-  };
-  
+  }
+
   return createChainableTypeChecker(validate);
 }

--- a/src/all.js
+++ b/src/all.js
@@ -1,3 +1,5 @@
+import {createChainableTypeChecker} from './common';
+
 export default function all(...propTypes) {
   if (propTypes === undefined) {
     throw new Error('No validations provided');
@@ -11,7 +13,7 @@ export default function all(...propTypes) {
     throw new Error('No validations provided');
   }
 
-  return function validate(props, propName, componentName) {
+  function validate(props, propName, componentName) {
     for (let i = 0; i < propTypes.length; i++) {
       const result = propTypes[i](props, propName, componentName);
 
@@ -20,4 +22,6 @@ export default function all(...propTypes) {
       }
     }
   };
+  
+  return createChainableTypeChecker(validate);
 }

--- a/test/allSpec.js
+++ b/test/allSpec.js
@@ -56,4 +56,19 @@ describe('all', function() {
 
     validators[2].should.not.have.been.called;
   });
+
+  it('always fails when prop value is missing and isRequired is used', function() {
+    const missingPropName = 'missing';
+    const allValidator = all(...validators).isRequired;
+    const expectedErr = new Error(
+      `Required prop '${missingPropName}' was not specified in '${componentName}'.`
+    );
+
+    const result = allValidator(props, missingPropName, componentName);
+    expect(result.toString()).to.equal(expectedErr.toString()); // cannot compare values, as we got different Error instances here.
+
+    validators[0].should.not.have.been.called;
+    validators[1].should.not.have.been.called;
+    validators[2].should.not.have.been.called;
+  });
 });


### PR DESCRIPTION
@jquense Hello Jason, I miss possibility of `.isRequired` when creating propType using `all` helper, so I added it. Could you review and publish please? :) Thanks.
